### PR TITLE
tox.ini: Remove py25

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py25, py26, py27
+envlist = py26, py27
 sitepackages = False
 
 [testenv]


### PR DESCRIPTION
Python 2.5 is old. Tox and virtualenv don't support it anymore, IIRC
