### PR TITLE
skipped output missing in xml files

### DIFF
--- a/junit_xml/__init__.py
+++ b/junit_xml/__init__.py
@@ -136,7 +136,7 @@ class TestSuite(object):
                 if case.skipped_message:
                     attrs['message'] = case.skipped_message
                 skipped_element = ET.Element("skipped", attrs)
-                if case.error_output:
+                if case.skipped_output:
                     skipped_element.text = case.skipped_output
                 test_case_element.append(skipped_element)
 


### PR DESCRIPTION
At the moment the contents of skipped_output are only written to the xml file if error_output is not empty. This is most likely a bug.