### PR TITLE
Aggregate testsuite attributes

### DIFF
--- a/junit_xml/__init__.py
+++ b/junit_xml/__init__.py
@@ -4,7 +4,7 @@ import sys, re
 import xml.etree.ElementTree as ET
 import xml.dom.minidom
 
-from six import u
+from six import u, iteritems
 
 try:
     # Python 2
@@ -172,7 +172,7 @@ class TestSuite(object):
             for key in ['time']:
               attributes[key] += float(ts_xml.get(key, 0))
             xml_element.append(ts_xml)
-        for key, value in attributes.iteritems():
+        for key, value in iteritems(attributes):
           xml_element.set(key, str(value))
 
         xml_string = ET.tostring(xml_element, encoding=encoding)

--- a/test_junit_xml.py
+++ b/test_junit_xml.py
@@ -136,7 +136,7 @@ class TestSuiteTests(unittest.TestCase):
         xml_string = TestSuite.to_xml_string(test_suites)
         expected_xml_string = textwrap.dedent("""
             <?xml version="1.0" ?>
-            <testsuites>
+            <testsuites errors="0" failures="0" skipped="0" tests="2" time="0.0">
             \t<testsuite errors="0" failures="0" name="suite1" skipped="0" tests="1" time="0">
             \t\t<testcase name="Test1"/>
             \t</testsuite>


### PR DESCRIPTION
Per the example provided in the docstring, we should aggregate certain
attributes of the <testsuite> elements into the top level <testsuites>
element.

Issue reported in https://github.com/kyrus/python-junit-xml/issues/26.