### PR TITLE
Add configurable failure and error types

### DIFF
--- a/junit_xml/__init__.py
+++ b/junit_xml/__init__.py
@@ -161,6 +161,8 @@ class TestSuite(object):
                 attrs = {'type': 'error'}
                 if case.error_message:
                     attrs['message'] = decode(case.error_message, encoding)
+                if case.error_type:
+                    attrs['type'] = decode(case.error_type, encoding)
                 error_element = ET.Element("error", attrs)
                 if case.error_output:
                     error_element.text = decode(case.error_output, encoding)
@@ -280,17 +282,20 @@ class TestCase(object):
         self.classname = classname
         self.error_message = None
         self.error_output = None
+        self.error_type = None
         self.failure_message = None
         self.failure_output = None
         self.skipped_message = None
         self.skipped_output = None
 
-    def add_error_info(self, message=None, output=None):
+    def add_error_info(self, message=None, output=None, error_type=None):
         """Adds an error message, output, or both to the test case"""
         if message:
             self.error_message = message
         if output:
             self.error_output = output
+        if error_type:
+            self.error_type = error_type
 
     def add_failure_info(self, message=None, output=None):
         """Adds a failure message, output, or both to the test case"""

--- a/junit_xml/__init__.py
+++ b/junit_xml/__init__.py
@@ -151,6 +151,8 @@ class TestSuite(object):
                 attrs = {'type': 'failure'}
                 if case.failure_message:
                     attrs['message'] = decode(case.failure_message, encoding)
+                if case.failure_type:
+                    attrs['type'] = decode(case.failure_type, encoding)
                 failure_element = ET.Element("failure", attrs)
                 if case.failure_output:
                     failure_element.text = decode(case.failure_output, encoding)
@@ -285,6 +287,7 @@ class TestCase(object):
         self.error_type = None
         self.failure_message = None
         self.failure_output = None
+        self.failure_type = None
         self.skipped_message = None
         self.skipped_output = None
 
@@ -297,12 +300,14 @@ class TestCase(object):
         if error_type:
             self.error_type = error_type
 
-    def add_failure_info(self, message=None, output=None):
+    def add_failure_info(self, message=None, output=None, failure_type=None):
         """Adds a failure message, output, or both to the test case"""
         if message:
             self.failure_message = message
         if output:
             self.failure_output = output
+        if failure_type:
+            self.failure_type = failure_type
 
     def add_skipped_info(self, message=None, output=None):
         """Adds a skipped message, output, or both to the test case"""

--- a/test_junit_xml.py
+++ b/test_junit_xml.py
@@ -324,13 +324,27 @@ class TestCaseTests(unittest.TestCase):
         verify_test_case(
             self, tcs[0], {'name': 'Error-Output'}, error_output="I errored!")
 
+    def test_init_error_type(self):
+        tc = TestCase('Error-Type')
+        tc.add_error_info(error_type='com.example.Error')
+        (ts, tcs) = serialize_and_read(TestSuite('test', [tc]))[0]
+        verify_test_case(self, tcs[0], {'name': 'Error-Type'})
+
+        tc.add_error_info("error message")
+        (ts, tcs) = serialize_and_read(TestSuite('test', [tc]))[0]
+        verify_test_case(
+            self, tcs[0], {'name': 'Error-Type'},
+            error_message="error message",
+            error_type='com.example.Error')
+
     def test_init_error(self):
         tc = TestCase('Error-Message-and-Output')
         tc.add_error_info("error message", "I errored!")
         (ts, tcs) = serialize_and_read(TestSuite('test', [tc]))[0]
         verify_test_case(
             self, tcs[0], {'name': 'Error-Message-and-Output'},
-            error_message="error message", error_output="I errored!")
+            error_message="error message", error_output="I errored!",
+            error_type="error")
 
     def test_init_skipped_message(self):
         tc = TestCase('Skipped-Message')
@@ -421,7 +435,7 @@ class TestCaseTests(unittest.TestCase):
 
 
 def verify_test_case(tc, test_case_element, expected_attributes,
-                     error_message=None, error_output=None,
+                     error_message=None, error_output=None, error_type=None,
                      failure_message=None, failure_output=None,
                      skipped_message=None, skipped_output=None,
                      stdout=None, stderr=None):
@@ -449,6 +463,10 @@ def verify_test_case(tc, test_case_element, expected_attributes,
         if error_message:
             tc.assertEqual(
                 error_message, errors[0].attributes['message'].value)
+
+        if error_type and errors:
+            tc.assertEqual(
+                error_type, errors[0].attributes['type'].value)
 
         if error_output:
             tc.assertEqual(

--- a/test_junit_xml.py
+++ b/test_junit_xml.py
@@ -301,13 +301,27 @@ class TestCaseTests(unittest.TestCase):
             self, tcs[0], {'name': 'Failure-Output'},
             failure_output="I failed!")
 
+    def test_init_failure_type(self):
+        tc = TestCase('Failure-Type')
+        tc.add_failure_info(failure_type='com.example.Error')
+        (ts, tcs) = serialize_and_read(TestSuite('test', [tc]))[0]
+        verify_test_case(self, tcs[0], {'name': 'Failure-Type'})
+
+        tc.add_failure_info("failure message")
+        (ts, tcs) = serialize_and_read(TestSuite('test', [tc]))[0]
+        verify_test_case(
+            self, tcs[0], {'name': 'Failure-Type'},
+            failure_message="failure message",
+            failure_type='com.example.Error')
+
     def test_init_failure(self):
         tc = TestCase('Failure-Message-and-Output')
         tc.add_failure_info("failure message", "I failed!")
         (ts, tcs) = serialize_and_read(TestSuite('test', [tc]))[0]
         verify_test_case(
             self, tcs[0], {'name': 'Failure-Message-and-Output'},
-            failure_message="failure message", failure_output="I failed!")
+            failure_message="failure message", failure_output="I failed!",
+            failure_type='failure')
 
     def test_init_error_message(self):
         tc = TestCase('Error-Message')
@@ -437,6 +451,7 @@ class TestCaseTests(unittest.TestCase):
 def verify_test_case(tc, test_case_element, expected_attributes,
                      error_message=None, error_output=None, error_type=None,
                      failure_message=None, failure_output=None,
+                     failure_type=None,
                      skipped_message=None, skipped_output=None,
                      stdout=None, stderr=None):
     for k, v in expected_attributes.items():
@@ -481,6 +496,10 @@ def verify_test_case(tc, test_case_element, expected_attributes,
         if failure_message:
             tc.assertEqual(
                 failure_message, failures[0].attributes['message'].value)
+
+        if failure_type and failures:
+            tc.assertEqual(
+                failure_type, failures[0].attributes['type'].value)
 
         if failure_output:
             tc.assertEqual(


### PR DESCRIPTION
Summary: Add configurable failure and error types so we can 
produce XML with specified exception classes.

Test plan: `python setup.py test`
