### PR TITLE
Remove Python 3.2 Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ env:
     - TOXENV=py26
     - TOXENV=py27
     - TOXENV=pypy
-    - TOXENV=py32
     - TOXENV=py33
     - TOXENV=py34
     - TOXENV=cover


### PR DESCRIPTION
Summary: Doesn't look like 3.2 is supported anymore:

```
/home/travis/virtualenv/python2.7.12/lib/python2.7/site-packages/virtualenv_support/pip-8.1.2-py2.py3-none-any.whl/pip/_vendor/pkg_resources/__init__.py:80:
UserWarning: Support for Python 3.0-3.2 has been dropped. Future
versions will fail here.
```

Test plan: Travis run on PR.