### PR TITLE
Added test case attributes

### DIFF
--- a/junit_xml/__init__.py
+++ b/junit_xml/__init__.py
@@ -138,10 +138,26 @@ class TestSuite(object):
         for case in self.test_cases:
             test_case_attributes = dict()
             test_case_attributes['name'] = decode(case.name, encoding)
+            if case.assertions:
+                test_case_attributes['assertions'] = decode(case.assertions, encoding)
             if case.elapsed_sec:
                 test_case_attributes['time'] = "%f" % case.elapsed_sec
+            if case.timestamp:
+                test_case_attributes['timestamp'] = decode(case.timestamp, encoding)
             if case.classname:
                 test_case_attributes['classname'] = decode(case.classname, encoding)
+            if case.status:
+                test_case_attributes['status'] = decode(case.status, encoding)
+            if case.category:
+                test_case_attributes['class'] = decode(case.category, encoding)
+            if case.file:
+                test_case_attributes['file'] = decode(case.file, encoding)
+            if case.line:
+                test_case_attributes['line'] = decode(case.line, encoding)
+            if case.log:
+                test_case_attributes['log'] = decode(case.log, encoding)
+            if case.url:
+                test_case_attributes['url'] = decode(case.url, encoding)
 
             test_case_element = ET.SubElement(
                 xml_element, "testcase", test_case_attributes)
@@ -250,7 +266,7 @@ class TestSuite(object):
     def _clean_illegal_xml_chars(string_to_clean):
         """
         Removes any illegal unicode characters from the given XML string.
-        
+
         @see: http://stackoverflow.com/questions/1707890/fast-way-to-filter-illegal-xml-unicode-chars-in-python
         """
 
@@ -275,13 +291,23 @@ class TestSuite(object):
 class TestCase(object):
     """A JUnit test case with a result and possibly some stdout or stderr"""
 
-    def __init__(self, name, classname=None, elapsed_sec=None, stdout=None,
-                 stderr=None):
+    def __init__(self, name, assertions=None, elapsed_sec=None,
+            timestamp=None, classname=None, status=None, category=None, file=None, line=None,
+            log=None, group=None, url=None, stdout=None, stderr=None):
         self.name = name
+        self.assertions = assertions
         self.elapsed_sec = elapsed_sec
+        self.timestamp = timestamp
+        self.classname = classname
+        self.status = status
+        self.category = category
+        self.file = file
+        self.line = line
+        self.log = log
+        self.url = url
         self.stdout = stdout
         self.stderr = stderr
-        self.classname = classname
+
         self.error_message = None
         self.error_output = None
         self.error_type = None

--- a/test_junit_xml.py
+++ b/test_junit_xml.py
@@ -251,23 +251,35 @@ class TestCaseTests(unittest.TestCase):
 
     def test_init_classname(self):
         (ts, tcs) = serialize_and_read(
-            TestSuite('test', [TestCase('Test1', 'some.class.name')]))[0]
+            TestSuite('test',
+                      [TestCase(name='Test1', classname='some.class.name')]))[0]
         verify_test_case(
             self, tcs[0], {'name': 'Test1', 'classname': 'some.class.name'})
 
     def test_init_classname_time(self):
         (ts, tcs) = serialize_and_read(
             TestSuite('test',
-                      [TestCase('Test1', 'some.class.name', 123.345)]))[0]
+                      [TestCase(name='Test1', classname='some.class.name',
+                                elapsed_sec=123.345)]))[0]
         verify_test_case(
             self, tcs[0], {'name': 'Test1', 'classname': 'some.class.name',
                            'time': ("%f" % 123.345)})
 
+    def test_init_classname_time_timestamp(self):
+        (ts, tcs) = serialize_and_read(
+            TestSuite('test',
+                      [TestCase(name='Test1', classname='some.class.name',
+                                elapsed_sec=123.345, timestamp=99999)]))[0]
+        verify_test_case(
+            self, tcs[0], {'name': 'Test1', 'classname': 'some.class.name',
+                           'time': ("%f" % 123.345),
+                           'timestamp': ("%s" % 99999)})
+
     def test_init_stderr(self):
         (ts, tcs) = serialize_and_read(
             TestSuite(
-                'test', [TestCase('Test1', 'some.class.name', 123.345,
-                                  stderr='I am stderr!')]))[0]
+                'test', [TestCase(name='Test1', classname='some.class.name',
+                            elapsed_sec=123.345, stderr='I am stderr!')]))[0]
         verify_test_case(
             self, tcs[0],
             {'name': 'Test1', 'classname': 'some.class.name',
@@ -277,8 +289,9 @@ class TestCaseTests(unittest.TestCase):
         (ts, tcs) = serialize_and_read(
             TestSuite(
                 'test', [TestCase(
-                    'Test1', 'some.class.name', 123.345, 'I am stdout!',
-                    'I am stderr!')]))[0]
+                    name='Test1', classname='some.class.name',
+                    elapsed_sec=123.345, stdout='I am stdout!',
+                    stderr='I am stderr!')]))[0]
         verify_test_case(
             self, tcs[0],
             {'name': 'Test1', 'classname': 'some.class.name',
@@ -414,9 +427,12 @@ class TestCaseTests(unittest.TestCase):
                 "failure message with illegal unicode char: []"))
 
     def test_init_utf8(self):
-        tc = TestCase('Test äöü', 'some.class.name.äöü', 123.345, 'I am stdöüt!', 'I am stdärr!')
+        tc = TestCase(name='Test äöü', classname='some.class.name.äöü',
+                      elapsed_sec=123.345, stdout='I am stdöüt!',
+                      stderr='I am stdärr!')
         tc.add_skipped_info(message='Skipped äöü', output="I skippäd!")
-        tc.add_error_info(message='Skipped error äöü', output="I skippäd with an error!")
+        tc.add_error_info(message='Skipped error äöü',
+                          output="I skippäd with an error!")
         test_suite = TestSuite('Test UTF-8', [tc])
         (ts, tcs) = serialize_and_read(test_suite, encoding='utf-8')[0]
         verify_test_case(self, tcs[0], {'name': decode('Test äöü', 'utf-8'),
@@ -429,8 +445,11 @@ class TestCaseTests(unittest.TestCase):
                         error_output=decode('I skippäd with an error!', 'utf-8'))
 
     def test_init_unicode(self):
-        tc = TestCase(decode('Test äöü', 'utf-8'), decode('some.class.name.äöü', 'utf-8'), 123.345,
-                      decode('I am stdöüt!', 'utf-8'), decode('I am stdärr!', 'utf-8'))
+        tc = TestCase(name=decode('Test äöü', 'utf-8'),
+                      classname=decode('some.class.name.äöü', 'utf-8'),
+                      elapsed_sec=123.345,
+                      stdout=decode('I am stdöüt!', 'utf-8'),
+                      stderr=decode('I am stdärr!', 'utf-8'))
         tc.add_skipped_info(message=decode('Skipped äöü', 'utf-8'),
                             output=decode('I skippäd!', 'utf-8'))
         tc.add_error_info(message=decode('Skipped error äöü', 'utf-8'),
@@ -441,11 +460,12 @@ class TestCaseTests(unittest.TestCase):
         verify_test_case(self, tcs[0], {'name': decode('Test äöü', 'utf-8'),
                                         'classname': decode('some.class.name.äöü', 'utf-8'),
                                         'time': ("%f" % 123.345)},
-                        stdout=decode('I am stdöüt!', 'utf-8'), stderr=decode('I am stdärr!', 'utf-8'),
-                        skipped_message=decode('Skipped äöü', 'utf-8'),
-                        skipped_output=decode('I skippäd!', 'utf-8'),
-                        error_message=decode('Skipped error äöü', 'utf-8'),
-                        error_output=decode('I skippäd with an error!', 'utf-8'))
+                         stdout=decode('I am stdöüt!', 'utf-8'),
+                         stderr=decode('I am stdärr!', 'utf-8'),
+                         skipped_message=decode('Skipped äöü', 'utf-8'),
+                         skipped_output=decode('I skippäd!', 'utf-8'),
+                         error_message=decode('Skipped error äöü', 'utf-8'),
+                         error_output=decode('I skippäd with an error!', 'utf-8'))
 
 
 def verify_test_case(tc, test_case_element, expected_attributes,


### PR DESCRIPTION
People were requesting an attribute 'timestamp' in JUnit test cases as there is in TestNG.
I don't know since when, but now JUnit XML allows new attributes for testcases...

See how the Jenkins plugin has included these attributes:
https://github.com/jenkinsci/xunit-plugin/blob/master/src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd/junit-10.xsd#L80