### PR TITLE
Do not throw Exception exceptions. Use TypeError that is more specific

### DIFF
--- a/junit_xml/__init__.py
+++ b/junit_xml/__init__.py
@@ -88,7 +88,7 @@ class TestSuite(object):
         try:
             iter(test_cases)
         except TypeError:
-            raise Exception('test_cases must be a list of test cases')
+            raise TypeError('test_cases must be a list of test cases')
         self.test_cases = test_cases
         self.timestamp = timestamp
         self.hostname = hostname
@@ -249,7 +249,7 @@ class TestSuite(object):
         try:
             iter(test_suites)
         except TypeError:
-            raise Exception('test_suites must be a list of test suites')
+            raise TypeError('test_suites must be a list of test suites')
 
         xml_element = ET.Element("testsuites")
         attributes = defaultdict(int)

--- a/tests/test_test_suite.py
+++ b/tests/test_test_suite.py
@@ -13,7 +13,7 @@ from .serializer import serialize_and_read
 
 
 def test_single_suite_single_test_case():
-    with pytest.raises(Exception) as excinfo:
+    with pytest.raises(TypeError) as excinfo:
         serialize_and_read(Suite('test', Case('Test1')), to_file=True)[0]
     assert str(excinfo.value) == 'test_cases must be a list of test cases'
 
@@ -217,6 +217,6 @@ def test_to_xml_string():
 def test_to_xml_string_test_suites_not_a_list():
     test_suites = Suite('suite1', [Case('Test1')])
 
-    with pytest.raises(Exception) as excinfo:
+    with pytest.raises(TypeError) as excinfo:
         Suite.to_xml_string(test_suites)
     assert str(excinfo.value) == 'test_suites must be a list of test suites'


### PR DESCRIPTION
When py27 support is dropped we can use type annotations instead. Now we only check that the input data is itarable. Strings and dicts are accepted in the type check. I think this is good enough for now.

My earlier pr:s must be merged before this can be properly reviewed and merged.