### PR TITLE
Change lib interface

### DIFF
--- a/tests/serializer.py
+++ b/tests/serializer.py
@@ -5,7 +5,7 @@ from xml.dom import minidom
 
 from six import PY2
 
-from junit_xml import TestSuite as Suite
+from junit_xml import to_xml_report_file, to_xml_report_string
 
 
 def serialize_and_read(test_suites, to_file=False, prettyprint=False, encoding=None):
@@ -20,12 +20,12 @@ def serialize_and_read(test_suites, to_file=False, prettyprint=False, encoding=N
         fd, filename = tempfile.mkstemp(text=True)
         os.close(fd)
         with codecs.open(filename, mode="w", encoding=encoding) as f:
-            Suite.to_file(f, test_suites, prettyprint=prettyprint, encoding=encoding)
+            to_xml_report_file(f, test_suites, prettyprint=prettyprint, encoding=encoding)
         print("Serialized XML to temp file [%s]" % filename)
         xmldoc = minidom.parse(filename)
         os.remove(filename)
     else:
-        xml_string = Suite.to_xml_string(test_suites, prettyprint=prettyprint, encoding=encoding)
+        xml_string = to_xml_report_string(test_suites, prettyprint=prettyprint, encoding=encoding)
         if PY2:
             assert isinstance(xml_string, unicode)  # noqa: F821
         print("Serialized XML to string:\n%s" % xml_string)


### PR DESCRIPTION
Move TestSuite.to_xml_string and TestSuite.to_file to functions that are not part of the TestSuite class. Add deprecation warnings for old interface

This is a suggestion as a solution to my issue https://github.com/kyrus/python-junit-xml/issues/61.

I would like to go further and remove TestSuite.to_file (with deprecation). Should I update the pr with that instead?
