### PR TITLE
Run tests with Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ matrix:
       dist: xenial
       sudo: true
       env: TOXENV=py37
+    - python: 3.8-dev
+      dist: xenial
+      sudo: true
+      env: TOXENV=py38
 
 env:
   - TOXENV=py27

--- a/junit_xml/__init__.py
+++ b/junit_xml/__init__.py
@@ -124,15 +124,15 @@ class TestSuite(object):
 
         # build the test suite element
         test_suite_attributes = dict()
-        test_suite_attributes["name"] = decode(self.name, encoding)
         if any(c.assertions for c in self.test_cases):
             test_suite_attributes["assertions"] = str(sum([int(c.assertions) for c in self.test_cases if c.assertions]))
         test_suite_attributes["disabled"] = str(len([c for c in self.test_cases if not c.is_enabled]))
-        test_suite_attributes["failures"] = str(len([c for c in self.test_cases if c.is_failure()]))
         test_suite_attributes["errors"] = str(len([c for c in self.test_cases if c.is_error()]))
+        test_suite_attributes["failures"] = str(len([c for c in self.test_cases if c.is_failure()]))
+        test_suite_attributes["name"] = decode(self.name, encoding)
         test_suite_attributes["skipped"] = str(len([c for c in self.test_cases if c.is_skipped()]))
-        test_suite_attributes["time"] = str(sum(c.elapsed_sec for c in self.test_cases if c.elapsed_sec))
         test_suite_attributes["tests"] = str(len(self.test_cases))
+        test_suite_attributes["time"] = str(sum(c.elapsed_sec for c in self.test_cases if c.elapsed_sec))
 
         if self.hostname:
             test_suite_attributes["hostname"] = decode(self.hostname, encoding)
@@ -288,7 +288,7 @@ def to_xml_report_string(test_suites, prettyprint=True, encoding=None):
     attributes = defaultdict(int)
     for ts in test_suites:
         ts_xml = ts.build_xml_doc(encoding=encoding)
-        for key in ["failures", "errors", "tests", "disabled"]:
+        for key in ["disabled", "errors", "failures", "tests"]:
             attributes[key] += int(ts_xml.get(key, 0))
         for key in ["time"]:
             attributes[key] += float(ts_xml.get(key, 0))

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, pypy, py35, py36, py37, cover, flake8
+envlist = py27, pypy, py35, py36, py37, py38, cover, flake8
 sitepackages = False
 
 [testenv]


### PR DESCRIPTION
This patch resolves several issues with Python 3.8 and enables testing with Tox:

https://bugzilla.redhat.com/show_bug.cgi?id=1716504

```
$ tox -e py38
...
――――――――――――――――――――――― test_to_xml_string ―――――――――――――――――――――――

    def test_to_xml_string():
        test_suites = [
            Suite(name="suite1", test_cases=[Case(name="Test1")]),
            Suite(name="suite2", test_cases=[Case(name="Test2")]),
        ]
        xml_string = to_xml_report_string(test_suites)
        if PY2:
            assert isinstance(xml_string, unicode)  # noqa: F821
        expected_xml_string = textwrap.dedent(
            """
            <?xml version="1.0" ?>
            <testsuites disabled="0" errors="0" failures="0" tests="2" time="0.0">
            \t<testsuite disabled="0" errors="0" failures="0" name="suite1" skipped="0" tests="1" time="0">
            \t\t<testcase name="Test1"/>
            \t</testsuite>
            \t<testsuite disabled="0" errors="0" failures="0" name="suite2" skipped="0" tests="1" time="0">
            \t\t<testcase name="Test2"/>
            \t</testsuite>
            </testsuites>
        """.strip(
                "\n"
            )
        )
>       assert xml_string == expected_xml_string
E       assert '<?xml versio...testsuites>\n' == '<?xml versio...testsuites>\n'
E         Skipping 49 identical trailing characters in diff, use -v to show
E           <?xml version="1.0" ?>
E         - <testsuites failures="0" errors="0" tests="2" disabled="0" time="0.0">
E         - 	<testsuite name="suite1" disabled="0" failures="0" errors="0" skipped="0" time="0" tests="1">
E         + <testsuites disabled="0" errors="0" failures="0" tests="2" time="0.0">
E         + 	<testsuite disabled="0" errors="0" failures="0" name="suite1" skipped="0" tests="1" time="0">
E           		<testcase name="Test1"/>...
E         
E         ...Full output truncated (5 lines hidden), use '-vv' to show

tests/test_test_suite.py:217: AssertionError

 tests/test_test_suite.py ⨯✓✓✓                     100% ██████████
- generated xml file: /home/rst/test/python-junit-xml/.tox/py38/log/junit-py38.xml -

Results (0.74s):
      45 passed
       1 failed
         - tests/test_test_suite.py:194 test_to_xml_string

```
