### PR TITLE
Adding Power support(ppc64le) with ci and testing to the project for architecture independent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,31 @@ matrix:
       dist: xenial
       sudo: true
       env: TOXENV=py38
+    - python: 2.7
+      dist: xenial
+      sudo: true
+      env: TOXENV=py27
+      arch: ppc64le  
+    - python: 3.6
+      dist: xenial
+      sudo: true
+      arch: ppc64le
+      env: TOXENV=py36
+    - python: 3.7
+      dist: xenial
+      sudo: true
+      env: TOXENV=py37
+      arch: ppc64le
+    - python: 3.8
+      dist: xenial
+      sudo: true
+      env: TOXENV=py38
+      arch: ppc64le
+    - python: 3.8
+      dist: xenial
+      sudo: true
+      env: TOXENV=cover
+      arch: ppc64le
 
 env:
   - TOXENV=py27


### PR DESCRIPTION
I am working for IBM to port cpu arch ppc64le for open sources.

This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro 
on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date.


This helps us simplify testing later when distributions are re-building and re-releasing,We typically build applications for customers and 
ISVs, and while we don't use this package directly,we do count on all of the packages in debian/ubuntu to build other packages. So we more likely have this as a second or 
third level dependency and couldn't tell you explicitly which features we use or our usage model,For more info tag @gerrith3.

Please help to verify and merge.