### PR TITLE
:memo: Updated README deprecated methods

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,12 +42,12 @@ Create a test suite, add a test case, and print it to the screen:
 
 .. code-block:: python
 
-    from junit_xml import TestSuite, TestCase
+    from junit_xml import TestCase, TestSuite, to_xml_report_string, to_xml_report_file 
 
     test_cases = [TestCase('Test1', 'some.class.name', 123.345, 'I am stdout!', 'I am stderr!')]
     ts = TestSuite("my test suite", test_cases)
     # pretty printing is on by default but can be disabled using prettyprint=False
-    print(TestSuite.to_xml_string([ts]))
+    print(to_xml_report_string([ts]))
 
 Produces the following output
 
@@ -73,7 +73,7 @@ Writing XML to a file:
 
     # you can also write the XML to a file and not pretty print it
     with open('output.xml', 'w') as f:
-        TestSuite.to_file(f, [ts], prettyprint=False)
+        to_xml_report_file(f, [ts], prettyprint=False)
 
 See the docs and unit tests for more examples.
 


### PR DESCRIPTION
updated import statement and replaced deprecated methods with : "to_xml_report_string and to_xml_report_file"